### PR TITLE
The python source code guessing line just makes no sense.

### DIFF
--- a/Products/MimetypesRegistry/mime_types/magic.py
+++ b/Products/MimetypesRegistry/mime_types/magic.py
@@ -240,7 +240,7 @@ magic = [
     [0L, 'string', '=', 'OTTO', 'application/x-font-otf'],
     [54L, 'string', '=', 'S T O P', 'application/x-ipod-firmware'],
     [0L, 'string', '=', 'BLENDER', 'application/x-blender'],
-    [20L, 'string', '=', 'import', 'text/x-python'],
+    [0L, 'string', '=', 'import ', 'text/x-python'],
 ]
 
 magicNumbers = []


### PR DESCRIPTION
Why position 20? It also needs a space or words like 'important' will match. It would be better to just remove the line.

When using things like field.set() to set a text value, which for example is done by transmogrifier and other import products, the guessing can create hard to analyze situations.
