### PR TITLE
more python3 fixes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,7 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Add Python 2 / 3 compatibility [pbauer]
 
 
 2.1.2 (2018-02-05)

--- a/Products/MimetypesRegistry/mime_types/__init__.py
+++ b/Products/MimetypesRegistry/mime_types/__init__.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
-from mtr_mimetypes import *
+from .mtr_mimetypes import *
 
-import mtr_mimetypes
-import py_mimetypes
-import smi_mimetypes
-import suppl_mimetypes
+from . import mtr_mimetypes
+from . import py_mimetypes
+from . import smi_mimetypes
+from . import suppl_mimetypes
 
 
 def initialize(registry):

--- a/Products/MimetypesRegistry/mime_types/mtr_mimetypes.py
+++ b/Products/MimetypesRegistry/mime_types/mtr_mimetypes.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 from Products.MimetypesRegistry.interfaces import IClassifier
 from Products.MimetypesRegistry.MimeTypeItem import MimeTypeItem
-# from types import InstanceType
 from zope.interface import implementer
 
+import inspect
 import re
 
 
@@ -155,8 +155,8 @@ reg_types = [
 
 def initialize(registry):
     for mt in reg_types:
-        # if not isinstance(mt, InstanceType):
-        #     mt = mt()
+        if inspect.isclass(mt):
+            mt = mt()
         registry.register(mt)
 
 

--- a/Products/MimetypesRegistry/mime_types/mtr_mimetypes.py
+++ b/Products/MimetypesRegistry/mime_types/mtr_mimetypes.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from Products.MimetypesRegistry.interfaces import IClassifier
 from Products.MimetypesRegistry.MimeTypeItem import MimeTypeItem
-from types import InstanceType
+# from types import InstanceType
 from zope.interface import implementer
 
 import re
@@ -155,8 +155,8 @@ reg_types = [
 
 def initialize(registry):
     for mt in reg_types:
-        if not isinstance(mt, InstanceType):
-            mt = mt()
+        # if not isinstance(mt, InstanceType):
+        #     mt = mt()
         registry.register(mt)
 
 


### PR DESCRIPTION
I'm not sure how to deal with the `isinstance(mt, InstanceType)` thing. InstanceType should only apply to old-style classes (not inheriting from object) which are gone in py3 (all classes inherit from object) but here it looks like it is (ab)used to check if mimetype class has been instanciated or not. I did not really look what a mt is so some help would be nice.