### PR TITLE
Fix missing comma in install_requires.

### DIFF
--- a/news/21.bugfix
+++ b/news/21.bugfix
@@ -1,0 +1,2 @@
+Fix missing comma in install_requires.
+[maurits]

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
     license='GPL',
     zip_safe=False,
     install_requires=[
-        'AccessControl>=3.0.0'
+        'AccessControl>=3.0.0',
         'Acquisition',
         'Products.CMFCore',
         'setuptools',


### PR DESCRIPTION
This caused the first item to be parsed as:

```
AccessControl>=3.0.0Acquisition
```

This resulted in a warning on startup with a recent setuptools:

```
pkg_resources/_vendor/packaging/specifiers.py:273: DeprecationWarning:
Creating a LegacyVersion has been deprecated and will be removed in the next major release
```