### PR TITLE
Fix classify() for magic classifier and binary data.

### DIFF
--- a/Products/MimetypesRegistry/MimeTypesRegistry.py
+++ b/Products/MimetypesRegistry/MimeTypesRegistry.py
@@ -303,6 +303,8 @@ class MimeTypesRegistry(UniqueObject, ActionProviderBase, Folder):
             if mt is None:
                 mt = self.globFilename(filename)
         if data and not mt:
+            if isinstance(data, str):
+                data = data.encode()
             for c in self._classifiers():
                 if c.classify(data):
                     mt = c
@@ -322,7 +324,6 @@ class MimeTypesRegistry(UniqueObject, ActionProviderBase, Folder):
                 failed = "text/x-unknown-content-type"
                 filename = filename or ""
                 data = data or ""
-                data = data.encode()
                 ct, enc = guess_content_type(filename, data, None)
                 if ct == failed:
                     ct = "text/plain"

--- a/Products/MimetypesRegistry/tests/test_mimetypes.py
+++ b/Products/MimetypesRegistry/tests/test_mimetypes.py
@@ -58,6 +58,10 @@ class TestMimeTypesclass(unittest.TestCase):
         mt = reg.classify("<?xml ?>")
         self.assertTrue(isinstance(mt, text_xml), str(mt))
 
+        # test magic classifiers
+        mt = reg.classify("BEGIN:VCARD\n")
+        self.assertEqual(str(mt), "text/vcard")
+
         # test no data return default
         mt = reg.classify("")
         self.assertTrue(isinstance(mt, text_plain), str(mt))
@@ -71,6 +75,10 @@ class TestMimeTypesclass(unittest.TestCase):
 
         # test unclassifiable data and file flag
         mt = reg.classify("baz", filename="xxx")
+        self.assertTrue(isinstance(mt, application_octet_stream), str(mt))
+
+        # test unclassifiable binary data
+        mt = reg.classify(b"\x01")
         self.assertTrue(isinstance(mt, application_octet_stream), str(mt))
 
     def testExtension(self):

--- a/news/39.bugfix
+++ b/news/39.bugfix
@@ -1,0 +1,1 @@
+Fixed classify() for magic classifier and binary data. @fdiary


### PR DESCRIPTION
This PR fixes an issue of `MimeTypesRegistry.classify()` that fails with magic classifier and binary data. #39